### PR TITLE
Possible fix for multiple connection joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ You may also supply an array of adapters and Waterline will map out the methods 
   - [MongoDB](https://github.com/balderdashy/sails-mongo) - *0.9+ compatible*
   - [Memory](https://github.com/balderdashy/sails-memory) - *0.9+ compatible*
   - [Disk](https://github.com/balderdashy/sails-disk) - *0.9+ compatible*
+  - [Microsoft SQL Server](https://github.com/cnect/sails-sqlserver-adapter)
   - [Redis](https://github.com/balderdashy/sails-redis)
   - [Riak](https://github.com/balderdashy/sails-riak)
   - [IRC](https://github.com/balderdashy/sails-irc)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ The current build status, immediate-term plans, and future goals of this reposit
 >
 > Before editing this file, please check out [How To Contribute to ROADMAP.md](https://gist.github.com/mikermcneil/bdad2108f3d9a9a5c5ed)- it's a quick read :)
 >
-> Also take a second to check that your feature request is relevant to Waterlin core and not one of its dependencies (e.g. waterline-schema, one of its adapters, etc.)  If you aren't sure, feel free to send the PR here and someone will make sure it finds its way to the right place.
+> Also take a second to check that your feature request is relevant to Waterline core and not one of its dependencies (e.g. waterline-schema, one of its adapters, etc.)  If you aren't sure, feel free to send the PR here and someone will make sure it finds its way to the right place.
 
 
 

--- a/lib/waterline/model/index.js
+++ b/lib/waterline/model/index.js
@@ -119,7 +119,10 @@ module.exports = function(context, mixins) {
 
     // Remove toJSON from the result, to prevent infinite recursion with
     // msgpack or other recursive object transformation tools.
-    obj.toJSON = null;
+    //
+    // Causes issues if set to null and will error in Sails if we delete it because blueprints call it.
+    //
+    // obj.toJSON = null;
 
     return obj;
   };

--- a/lib/waterline/model/index.js
+++ b/lib/waterline/model/index.js
@@ -107,21 +107,22 @@ module.exports = function(context, mixins) {
   // If any of the attributes are protected, the default toJSON method should
   // remove them.
   var protectedAttributes = _.compact(_.map(context._attributes, function(attr, key) {return attr.protected ? key : undefined;}));
-  if (protectedAttributes.length) {
-    prototypeFns.toJSON = function() {
-      var obj = this.toObject();
+
+  prototypeFns.toJSON = function() {
+    var obj = this.toObject();
+
+    if (protectedAttributes.length) {
       _.each(protectedAttributes, function(key) {
         delete obj[key];
       });
-      return obj;
-    };
-  }
-  // Otherwise just return the raw object
-  else {
-    prototypeFns.toJSON = function() {
-      return this.toObject();
-    };
-  }
+    }
+
+    // Remove toJSON from the result, to prevent infinite recursion with
+    // msgpack or other recursive object transformation tools.
+    obj.toJSON = null;
+
+    return obj;
+  };
 
   var prototype = _.extend(prototypeFns, mixins);
 

--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -43,17 +43,21 @@ module.exports = {
     if(!Array.isArray(valuesList)) return usageError('Invalid valuesList specified (should be an array!)', usage, cb);
     if(typeof cb !== 'function') return usageError('Invalid callback specified!', usage, cb);
 
-    valuesList = _.cloneDeep(valuesList);
-
-    // Remove all undefined values
-    valuesList = _.remove(valuesList, undefined);
-
     var errStr = _validateValues(_.cloneDeep(valuesList));
     if(errStr) return usageError(errStr, usage, cb);
 
     var records = [];
 
     function create(value, next) {
+
+      // Handle undefined values
+      if(value === undefined) {
+        setImmediate(function() {
+          return next();
+        });
+      }
+
+      // Create will take care of cloning values so original isn't mutated
       self.create(value, function(err, record) {
         if(err) return next(err);
         records.push(record);

--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -30,7 +30,21 @@ module.exports = function(values, cb) {
     values = args.pop();
   }
 
+  // Loop through values and pull out any buffers before cloning
+  var bufferValues = {};
+
+  _.each(_.keys(values), function(key) {
+    if(Buffer.isBuffer(values[key])) {
+      bufferValues[key] = values[key];
+    }
+  });
+
   values = _.cloneDeep(values) || {};
+
+  // Replace clone keys with the buffer values
+  _.each(_.keys(bufferValues), function(key) {
+      values[key] = bufferValues[key];
+  });
 
   // Remove all undefined values
   if(_.isArray(values)) {

--- a/lib/waterline/query/dql/destroy.js
+++ b/lib/waterline/query/dql/destroy.js
@@ -93,9 +93,11 @@ module.exports = function(criteria, cb) {
 
         if(mappedValues.length > 0) {
           criteria[refKey] = mappedValues;
+          collection.destroy(criteria).exec(next);
+        } else {
+          return next();
         }
 
-        collection.destroy(criteria).exec(next);
       }
 
       async.each(relations, destroyJoinTableRecords, function(err) {

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var util = require('./helpers');
 var hop = util.object.hasOwnProperty;
-var switchback = require('node-switchback');
+var switchback = require('switchback');
 var errorify = require('../error');
 var WLUsageError = require('../error/WLUsageError');
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "anchor": "~0.10.1",
     "async": "~0.9.0",
-    "bluebird": "~2.8.2",
+    "bluebird": "^2.9",
     "deep-diff": "~0.3.0",
     "lodash": "~2.4.1",
     "switchback": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "waterline",
   "description": "An ORM for Node.js and the Sails framework",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "homepage": "http://github.com/balderdashy/waterline",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "anchor": "~0.10.1",
     "async": "~0.9.0",
-    "bluebird": "~2.3.4",
+    "bluebird": "~2.8.2",
     "deep-diff": "~0.3.0",
     "lodash": "~2.4.1",
     "switchback": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "waterline",
   "description": "An ORM for Node.js and the Sails framework",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "homepage": "http://github.com/balderdashy/waterline",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "waterline",
   "description": "An ORM for Node.js and the Sails framework",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "homepage": "http://github.com/balderdashy/waterline",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bluebird": "~2.3.4",
     "deep-diff": "~0.3.0",
     "lodash": "~2.4.1",
-    "node-switchback": "~0.1.0",
+    "switchback": "~1.1.0",
     "prompt": "~0.2.12",
     "waterline-criteria": "~0.11.0",
     "waterline-schema": "~0.1.17"


### PR DESCRIPTION
This introduces a possible fix for issue #677 and similar issues, where joins across multiple adapters (at least with the memory adapter) don't work.

The problem is that after integrating the results from multiple connections and adapters, unserialization code is run that obliterates the join data (query/finders/basic.js:330).  This happens because the integrator doesn't remove the parent record's foreign key to the child, which is then used in the deserialization code to overwrite the joined data with the foreign key.
